### PR TITLE
Make properties readonly instead of classes

### DIFF
--- a/src/Amount/Amount.php
+++ b/src/Amount/Amount.php
@@ -7,9 +7,9 @@ namespace Money\Amount;
 use Money\Calculator\CalculatorInterface;
 use Money\Calculator\Provider\CalculatorProvider;
 
-readonly class Amount implements AmountInterface
+class Amount implements AmountInterface
 {
-    protected string $amount;
+    protected readonly string $amount;
 
     public function __construct(int|string $amount)
     {

--- a/src/Currency/Currency.php
+++ b/src/Currency/Currency.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Money\Currency;
 
-readonly class Currency implements CurrencyInterface, \JsonSerializable
+class Currency implements CurrencyInterface, \JsonSerializable
 {
-    private CurrencyInfo $currencyInfo;
+    private readonly CurrencyInfo $currencyInfo;
 
     public function __construct(string $code)
     {

--- a/src/Money.php
+++ b/src/Money.php
@@ -11,10 +11,10 @@ use Money\Calculator\Provider\CalculatorProvider;
 use Money\Currency\Currency;
 use Money\Currency\CurrencyInterface;
 
-readonly class Money implements \JsonSerializable, MoneyInterface
+class Money implements \JsonSerializable, MoneyInterface
 {
-    public AmountInterface $amount;
-    public CurrencyInterface $currency;
+    public readonly AmountInterface $amount;
+    public readonly CurrencyInterface $currency;
 
     public function __construct(int|string|AmountInterface $amount, string|CurrencyInterface $currency)
     {


### PR DESCRIPTION
Refactor to use `readonly` for individual properties instead of applying it to entire classes. This improves clarity and aligns better with the intended immutability of specific fields rather than the entire object.